### PR TITLE
Implement `everything` URL keyword

### DIFF
--- a/autoload/investigate/defaults.vim
+++ b/autoload/investigate/defaults.vim
@@ -182,7 +182,11 @@ function! s:SearchStringForSyntax(syntax, forDash)
   let l:command = s:UserOverrideForSyntax(a:syntax, a:forDash)
   if !empty(l:command) | return l:command | endif
 
-  if s:HasCustomCommandForFiletype(a:syntax)
+  if s:HasAllLanguagesURL()
+    let l:command = s:AllLanguagesURL()
+  endif
+
+  if empty(l:command) && s:HasCustomCommandForFiletype(a:syntax)
     let l:command = s:CustomCommandForFiletype(a:syntax)
   endif
 
@@ -267,6 +271,19 @@ function! s:SyntaxStringForFiletype(filetype)
   endif
 
   return l:string
+endfunction
+" }}}
+
+" All languages configuration ------ {{{
+function! s:AllLanguagesString()
+  return "g:investigate_url_for_everything"
+endfunction
+function! s:HasAllLanguagesURL()
+  return exists(s:AllLanguagesString())
+endfunction
+
+function! s:AllLanguagesURL()
+  return eval(s:AllLanguagesString())
 endfunction
 " }}}
 

--- a/doc/investigate.txt
+++ b/doc/investigate.txt
@@ -144,6 +144,10 @@ specific filetype. If you have a better one I'd love to hear about it via a
 pull request. This is the default ruby URL but if you were redefining it:
     let g:investigate_url_for_ruby="http://ruby-doc.com/search.html?q=^s"
 
+Using 'everything' as the <filetype> argument allows you to override the
+default URL for all filetypes. This enables you to use a single site for all
+languages.
+
 ------------------------------------------------------------------------------
 
 3.2 Configuration File                                 *investigate-conf-file*


### PR DESCRIPTION
This allows users to specify a single URL for all languages